### PR TITLE
prevent singleclick from firing on drag events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ DIRECTIONS.org
 *.exe
 *.obj
 *.out
+*.bower_components

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-# singleclick for Leaflet 0.7.*
+# singleclick for Leaflet 1.0.0-beta1 and greater
 
-This plugin extends `L.Map` to fire the `singleclick` event. The `singleclick` event is not part of Leaflet's core, and most likely never will be: [#108](https://github.com/Leaflet/Leaflet/issues/108)
+This plugin extends `L.Evented` to fire the `singleclick` event. A `singleclick` happens when clicking on something but not double-clicking for 500msec.
 
+The timeout can be configured by setting the `singleClickTimeout` option on the relevant `L.Evented`, like so:
 
-
-Note: For Leaflet 0.8 it could be possible to extend `L.Evented` instead, to have also Marker etc. support the `singleclick` event.
+```js
+marker.options.singleClickTimeout = 250;
+marker.on('singleclick', function(ev){ ... } );
+```
 
 ## live example
 
-http://alpstein.github.io/leaflet-singleclick_0.7/
+http://mazemap.github.io/Leaflet.singleclick/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# singleclick for Leaflet 1.0.0-beta1 and greater
+# Leaflet.singleclick
+
+
 
 This plugin extends `L.Evented` to fire the `singleclick` event. A `singleclick` happens when clicking on something but not double-clicking for 500msec.
 
@@ -9,6 +11,8 @@ marker.options.singleClickTimeout = 250;
 marker.on('singleclick', function(ev){ ... } );
 ```
 
-## live example
+Works with Leaflet 1.0.0-beta1 and greater. Does **not** work with 0.7.x.
+
+## Live example
 
 http://mazemap.github.io/Leaflet.singleclick/

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Leaflet.singleclick",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "homepage": "https://github.com/MazeMap/Leaflet.singleclick",
   "authors": [
     "Iván Sánchez Ortega <ivan@mazemap.no>"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Leaflet.singleclick",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/MazeMap/Leaflet.singleclick",
   "authors": [
     "Iván Sánchez Ortega <ivan@mazemap.no>"

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "Leaflet.singleclick",
+  "version": "0.1.0",
+  "homepage": "https://github.com/MazeMap/Leaflet.singleclick",
+  "authors": [
+    "Iván Sánchez Ortega <ivan@mazemap.no>"
+  ],
+  "description": "Allows Leaflet layers to fire 'singleclick' events",
+  "main": "singleclick.js",
+  "keywords": [
+    "leaflet",
+    "events"
+  ],
+  "license": "Apache",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "leaflet": "~1.0.0-beta.1"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -29,11 +29,22 @@ var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{
 map.options.singleClickTimeout = 250;
 
 map.on('singleclick',function ( e ) {
-	console.log( 'singleclick', e );
+	console.log( 'map singleclick', e );
 	L.popup().setLatLng( e.latlng )
-		.setContent( '<p><code>singleclick</code> at ' + e.latlng )
+		.setContent( '<p>Basemap <code>singleclick</code> at ' + e.latlng )
 		.openOn( map );
 } );
+
+var group = L.featureGroup().addTo(map);
+
+var circle = L.circle([51.505, -0.09], 1000).addTo(group).on('singleclick', function(ev) {
+	console.log( 'circle singleclick', ev );
+	L.DomEvent.stop(ev);
+	L.popup().setLatLng( ev.latlng )
+		.setContent( '<p>Circle <code>singleclick</code> at ' + ev.latlng )
+		.openOn( map );
+});
+circle.options.singleClickTimeout = 250;
 
 	</script>
 

--- a/index.html
+++ b/index.html
@@ -1,45 +1,41 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>singleclick example</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="http://leafletjs.com/dist/leaflet.css" />
-    <style type="text/css">#map { position: fixed; top: 0; left: 0; width: 100%; height: 100%; margin: 0; padding: 0; }</style>
-  </head>
-  <body>
-    <div id="map"></div>
+<head>
+	<title>Leaflet.singleclick example</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<style type="text/css">
+		#map { position: fixed; top: 0; left: 0; width: 100%; height: 100%; margin: 0; padding: 0; }
+	</style>
+	<link href="http://cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet.css" rel="stylesheet" type="text/css" />
+	<script src="http://cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet-src.js"></script>
+</head>
+<body>
+	<div id="map"></div>
 
-    <script type="text/javascript" src="http://leafletjs.com/dist/leaflet.js"></script>
-    
-    <script type="text/javascript" src="singleclick.js"></script>
+	<script type="text/javascript" src="singleclick.js"></script>
 
-    <script type="text/javascript">
-// create a map
-
-var div = document.createElement('div');
-div.setAttribute('style','position:fixed;margin:0;padding:0;left:0;top:0;width:100%;height:100%;');
-document.documentElement.appendChild(div);
+	<script type="text/javascript">
+var div = document.getElementById('map');
 
 var map = L.map(div).setView([51.505, -0.09], 13);
 
-L.tileLayer('https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
-    maxZoom: 18,
-    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
-        '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-        'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    id: 'examples.map-i875mjb7'
+var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
 }).addTo(map);
 
 // test
 
-map.on('singleclick',function ( e ) { 
-    console.log( 'singleclick', e ); 
-    L.popup().setLatLng( e.latlng )
-        .setContent( '<p><code>singleclick</code> at ' + e.latlng ) 
-        .openOn( map );
-} );
-    </script>
+map.options.singleClickTimeout = 250;
 
-  </body>
+map.on('singleclick',function ( e ) {
+	console.log( 'singleclick', e );
+	L.popup().setLatLng( e.latlng )
+		.setContent( '<p><code>singleclick</code> at ' + e.latlng )
+		.openOn( map );
+} );
+
+	</script>
+
+</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
   "name": "leaflet-singleclick",
-  "version": "0.5.0"
+  "version": "0.5.0",
+  "main": "singleclick.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "leaflet-singleclick",
+  "version": "0.5.0"
+}

--- a/singleclick.js
+++ b/singleclick.js
@@ -1,28 +1,42 @@
 
 
 L.Evented.addInitHook( function () {
+
 	this.on('click', this._scheduleSingleClick, this);
 	this.on('dblclick', this._cancelSingleClick, this);
 
 	this._singleClickTimeout = null;
+	this._cancel = false;
+	this._defaultTimeout = 500;
 });
 
 L.Evented.include({
 
 	_scheduleSingleClick: function(ev) {
-		this._cancelSingleClick();
+		this._cancelSingleClick(false);
+
 		this._singleClickTimeout = window.setTimeout(
 			L.bind(this._fireSingleClick, this, ev),
-			this.options.singleClickTimeout || 500);
+			this.options.singleClickTimeout || this._defaultTimeout);
 	},
 
-	_cancelSingleClick: function() {
+	_cancelSingleClick: function(t) {
 		window.clearTimeout(this._singleClickTimeout);
+		if(t !== false){
+			this._cancel = true;
+        	setTimeout(function(){ this._cancel=false; }.bind(this), (this.options.singleClickTimeout ? this.options.singleClickTimeout + 50 : this._defaultTimeout + 50) );
+		}
 	},
 
 	_fireSingleClick: function(ev) {
-		if (!ev.originalEvent._stopped) {
-			this.fire('singleclick', L.Util.extend(ev, {type: 'singleclick'}));
+		if (!ev.originalEvent._stopped && !this._cancel) {
+
+	        setTimeout(function(){
+	            if(!this._cancel){
+					this.fire('singleclick', L.Util.extend(ev, {type: 'singleclick'}));
+	            }
+	        }.bind(this), 50);
+
 		}
 	}
 })

--- a/singleclick.js
+++ b/singleclick.js
@@ -19,7 +19,9 @@ L.Evented.include({
     },
 
     _fireSingleClick: function(e){
-        this.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
+        if ( !e.originalEvent._stopped ) {
+            this.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
+        }
     },
 
     _clearTimeout: function(){

--- a/singleclick.js
+++ b/singleclick.js
@@ -10,6 +10,7 @@ L.Map.addInitHook( function () {
         that.on( 'click',    check_later );
         that.on( 'dblclick', function () { setTimeout( clear_h, 0 ); } );
         that.on( 'dragstart', function () { ignoreDragging = true; } );
+        that.on( 'dragend', function () { ignoreDragging = false; } );
     }
 
     function check_later( e )

--- a/singleclick.js
+++ b/singleclick.js
@@ -1,27 +1,33 @@
 L.Map.addInitHook( function () {
-    
+
     var that = this
     ,   h
+    ,   ignoreDragging = false
     ;
-    
+
     if (that.on)
     {
         that.on( 'click',    check_later );
         that.on( 'dblclick', function () { setTimeout( clear_h, 0 ); } );
+        that.on( 'dragstart', function () { ignoreDragging = true; } );
     }
-    
+
     function check_later( e )
     {
         clear_h();
-        
+
         h = setTimeout( check, 500 );
-        
+
         function check()
         {
-            that.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
+            if (!ignoreDragging) {
+                that.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
+            } else {
+                ignoreDragging = false;
+            }
         }
     }
-    
+
     function clear_h()
     {
         if (h != null)
@@ -30,5 +36,5 @@ L.Map.addInitHook( function () {
             h = null;
         }
     }
-    
+
 });

--- a/singleclick.js
+++ b/singleclick.js
@@ -1,34 +1,27 @@
-L.Map.addInitHook( function () {
-    
-    var that = this
-    ,   h
-    ;
-    
-    if (that.on)
-    {
-        that.on( 'click',    check_later );
-        that.on( 'dblclick', function () { setTimeout( clear_h, 0 ); } );
-    }
-    
-    function check_later( e )
-    {
-        clear_h();
-        
-        h = setTimeout( check, 500 );
-        
-        function check()
-        {
-            that.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
-        }
-    }
-    
-    function clear_h()
-    {
-        if (h != null)
-        {
-            clearTimeout( h );
-            h = null;
-        }
-    }
-    
+
+
+L.Evented.addInitHook( function () {
+	this.on('click', this._scheduleSingleClick, this);
+	this.on('dblclick', this._cancelSingleClick, this);
+
+	this._singleClickTimeout = null;
 });
+
+L.Evented.include({
+
+	_scheduleSingleClick: function(ev) {
+		this._cancelSingleClick();
+		this._singleClickTimeout = window.setTimeout(
+			L.bind(this._fireSingleClick, this, ev),
+			this.options.singleClickTimeout || 500);
+	},
+
+	_cancelSingleClick: function() {
+		window.clearTimeout(this._singleClickTimeout);
+	},
+
+	_fireSingleClick: function(ev) {
+		this.fire('singleclick', L.Util.extend(ev, {type: 'singleclick'}));
+	}
+})
+

--- a/singleclick.js
+++ b/singleclick.js
@@ -1,43 +1,33 @@
-
-
 L.Evented.addInitHook( function () {
+    this.h = null;
+    this.on( 'click', this.check_later, this );
+    this.on( 'dblclick', this.timeoutClear, this );
 
-	this.on('click', this._scheduleSingleClick, this);
-	this.on('dblclick', this._cancelSingleClick, this);
-
-	this._singleClickTimeout = null;
-	this._cancel = false;
-	this._defaultTimeout = 500;
 });
 
 L.Evented.include({
 
-	_scheduleSingleClick: function(ev) {
-		this._cancelSingleClick(false);
-
-		this._singleClickTimeout = window.setTimeout(
-			L.bind(this._fireSingleClick, this, ev),
-			this.options.singleClickTimeout || this._defaultTimeout);
+	timeoutClear : function(){
+		setTimeout( this.clear_h.bind(this), 0 );
 	},
 
-	_cancelSingleClick: function(t) {
-		window.clearTimeout(this._singleClickTimeout);
-		if(t !== false){
-			this._cancel = true;
-        	setTimeout(function(){ this._cancel=false; }.bind(this), (this.options.singleClickTimeout ? this.options.singleClickTimeout + 50 : this._defaultTimeout + 50) );
-		}
-	},
+    check_later: function(e) {
+        this.clear_h();
 
-	_fireSingleClick: function(ev) {
-		if (!ev.originalEvent._stopped && !this._cancel) {
+        this.h = setTimeout( this.check.bind(this, e), (this.options.singleClickTimeout || 500) );
+    },
 
-	        setTimeout(function(){
-	            if(!this._cancel){
-					this.fire('singleclick', L.Util.extend(ev, {type: 'singleclick'}));
-	            }
-	        }.bind(this), 50);
+    check: function(e){
+        this.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
+    },
 
-		}
-	}
+    clear_h: function(){
+        if (this.h != null)
+        {
+            clearTimeout( this.h );
+            this.h = null;
+        }
+    }
+
 })
 

--- a/singleclick.js
+++ b/singleclick.js
@@ -1,31 +1,32 @@
 L.Evented.addInitHook( function () {
-    this.h = null;
-    this.on( 'click', this.check_later, this );
-    this.on( 'dblclick', this.timeoutClear, this );
+    this._timerId = null;
+    this.on( 'click', this._scheduleSingleClick, this );
+    this.on( 'dblclick', this._cancelSingleClick, this );
 
 });
 
 L.Evented.include({
 
-	timeoutClear : function(){
-		setTimeout( this.clear_h.bind(this), 0 );
+	_cancelSingleClick : function(){
+		//This timeout is key to workaround an issue where double-click events are fired in this order on touch browsers: ['click', 'dblclick', 'click'] instead of ['click', 'click', 'dblclick']
+		setTimeout( this._clearTimeout.bind(this), 0 );
 	},
 
-    check_later: function(e) {
-        this.clear_h();
+    _scheduleSingleClick: function(e) {
+        this._clearTimeout();
 
-        this.h = setTimeout( this.check.bind(this, e), (this.options.singleClickTimeout || 500) );
+        this._timerId = setTimeout( this._fireSingleClick.bind(this, e), (this.options.singleClickTimeout || 500) );
     },
 
-    check: function(e){
+    _fireSingleClick: function(e){
         this.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
     },
 
-    clear_h: function(){
-        if (this.h != null)
+    _clearTimeout: function(){
+        if (this._timerId != null)
         {
-            clearTimeout( this.h );
-            this.h = null;
+            clearTimeout( this._timerId );
+            this._timerId = null;
         }
     }
 

--- a/singleclick.js
+++ b/singleclick.js
@@ -2,7 +2,8 @@ L.Evented.addInitHook( function () {
     this._timerId = null;
     this.on( 'click', this._scheduleSingleClick, this );
     this.on( 'dblclick', this._cancelSingleClick, this );
-
+    this.on( 'dragstart', this._cancelSingleClick, this );
+    this.on( 'zoomstart', this._cancelSingleClick, this );
 });
 
 L.Evented.include({

--- a/singleclick.js
+++ b/singleclick.js
@@ -1,22 +1,25 @@
 L.Evented.addInitHook( function () {
-    this._timerId = null;
+    this._singleClickTimeout = null;
     this.on( 'click', this._scheduleSingleClick, this );
-    this.on( 'dblclick', this._cancelSingleClick, this );
-    this.on( 'dragstart', this._cancelSingleClick, this );
-    this.on( 'zoomstart', this._cancelSingleClick, this );
+    this.on( 'dblclick dragstart zoomstart', this._cancelSingleClick, this );
 });
 
 L.Evented.include({
 
-	_cancelSingleClick : function(){
-		//This timeout is key to workaround an issue where double-click events are fired in this order on touch browsers: ['click', 'dblclick', 'click'] instead of ['click', 'click', 'dblclick']
-		setTimeout( this._clearTimeout.bind(this), 0 );
-	},
+    _cancelSingleClick : function(){
+        // This timeout is key to workaround an issue where double-click events
+        // are fired in this order on some touch browsers: ['click', 'dblclick', 'click']
+        // instead of ['click', 'click', 'dblclick']
+        setTimeout( this._clearSingleClickTimeout.bind(this), 0 );
+    },
 
     _scheduleSingleClick: function(e) {
-        this._clearTimeout();
+        this._clearSingleClickTimeout();
 
-        this._timerId = setTimeout( this._fireSingleClick.bind(this, e), (this.options.singleClickTimeout || 500) );
+        this._singleClickTimeout = setTimeout(
+            this._fireSingleClick.bind(this, e),
+            (this.options.singleClickTimeout || 500)
+        );
     },
 
     _fireSingleClick: function(e){
@@ -25,13 +28,12 @@ L.Evented.include({
         }
     },
 
-    _clearTimeout: function(){
-        if (this._timerId != null)
-        {
-            clearTimeout( this._timerId );
-            this._timerId = null;
+    _clearSingleClickTimeout: function(){
+        if (this._singleClickTimeout != null) {
+            clearTimeout( this._singleClickTimeout );
+            this._singleClickTimeout = null;
         }
     }
 
-})
+});
 

--- a/singleclick.js
+++ b/singleclick.js
@@ -21,7 +21,9 @@ L.Evented.include({
 	},
 
 	_fireSingleClick: function(ev) {
-		this.fire('singleclick', L.Util.extend(ev, {type: 'singleclick'}));
+		if (!ev.originalEvent._stopped) {
+			this.fire('singleclick', L.Util.extend(ev, {type: 'singleclick'}));
+		}
 	}
 })
 


### PR DESCRIPTION
I noticed the singleclick event was firing after drag (pan) movements, and I really didn't want that to happen...
