### PR TITLE
Add package.json so module can be imported via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "leaflet-singleclick",
+    "version": "0.0.1",
+    "main": "singleclick.js"
+}


### PR DESCRIPTION
I've added a minimal package.json file so that this plugin can be imported via npm. You may want to add further info. See https://docs.npmjs.com/files/package.json

I removed `_0.7` from the repo name because npm apparently couldn't handle the underscore in the url. If you add this to the npm repo, it can be imported without referencing github and this problem can be avoided.
https://www.npmjs.com/

Here's the entry in package.json for the app that consumes this plugin. 
`"leaflet-singleclick": "github:azavea/leaflet-singleclick#feature/lf/module"`
And in the file that imports the plugin.

```
import L from 'leaflet';
import 'leaflet-singleclick';
```
